### PR TITLE
Update the url of validation schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ If you want to run Tyk Schemas manually:
 
 ## Schemas
 
-Tyk Schemas VS Code extension uses [tyk-schemas](https://github.com/letzya/tyk-schemas) project to load schemas. 
+Tyk Schemas VS Code extension uses [tyk-schemas](https://github.com/tykTechnologies/tyk-schemas) project to load schemas. 
 
-Please refer to [tyk-schemas](https://github.com/letzya/tyk-schemas) project repository to see details of the provided schemas.
+Please refer to [tyk-schemas](https://github.com/tykTechnologies/tyk-schemas) project repository to see details of the provided schemas.
 
 ## Community
 

--- a/extension.js
+++ b/extension.js
@@ -19,14 +19,14 @@ function activate(context) {
 			"fileMatch": [
 				"tyk.*.conf"
 			],
-			"url": "https://raw.githubusercontent.com/letzya/tyk-schemas/main/schema_tyk.oss.conf",
+			"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/main/JSON/draft-07/schema_tyk.oss.conf",
 			"addedBy": "tyk"
 		},
 		{
 			"fileMatch": [
 				"apikey.*.json"
 			],
-			"url": "https://raw.githubusercontent.com/letzya/tyk-schemas/main/schema_apikey.json",
+			"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/main/JSON/draft-07/schema_apikey.json",
 			"addedBy": "tyk"
 		},
 		{
@@ -34,7 +34,7 @@ function activate(context) {
 				"apidef.*.json",
 				"TykDefinition-*.json"
 			],
-			"url": "https://raw.githubusercontent.com/letzya/tyk-schemas/main/schema_apidef_lean.json",
+			"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/main/JSON/draft-07/schema_apidef_lean.json",
 			"addedBy": "tyk"
 		},
 		{

--- a/package.json
+++ b/package.json
@@ -40,19 +40,27 @@
 				"fileMatch": [
 					"tyk.*.conf"
 				],
-				"url": "https://raw.githubusercontent.com/letzya/tyk-schemas/main/schema_tyk.oss.conf"
+				"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/main/JSON/draft-07/schema_tyk.oss.conf"
 			},
 			{
 				"fileMatch": [
 					"apikey.*.json"
 				],
-				"url": "https://raw.githubusercontent.com/letzya/tyk-schemas/main/schema_apikey.json"
+				"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/main/JSON/draft-07/schema_apikey.json"
 			},
 			{
 				"fileMatch": [
-					"apidef.*.json"
+					"apidef.*.json",
+					"TykDefinition-*.json"
 				],
-				"url": "https://raw.githubusercontent.com/letzya/tyk-schemas/main/schema_apidef_lean.json"
+				"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/main/JSON/draft-07/schema_apidef_lean.json"
+			},
+			{
+				"fileMatch": [
+					"oasapidef.*.json",
+					"TykOasApiDef-*.json"
+				],
+				"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/main/JSON/draft-04/schema_apidefoas.json"
 			}
 		],
 		"commands": [


### PR DESCRIPTION
Resolves #3 

This PR updates links of JSON validation schemas to use https://github.com/TykTechnologies/tyk-schemas 

Signed-off-by: Burak Sekili <buraksekili@gmail.com>