### PR TITLE
Update expected file name format for Api Definition objects

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -17,21 +17,23 @@ function activate(context) {
 	const TykSchemas = [
 		{
 			"fileMatch": [
-				"tyk.*.conf"
+				"tyk.conf",
+				"tyk-*.conf"
 			],
 			"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/v0.1/JSON/draft-07/schema_tyk.oss.conf",
 			"addedBy": "tyk"
 		},
 		{
 			"fileMatch": [
-				"apikey.*.json"
+				"apikey-*.json"
 			],
 			"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/v0.1/JSON/draft-07/schema_apikey.json",
 			"addedBy": "tyk"
 		},
 		{
 			"fileMatch": [
-				"apidef.*.json",
+				"apidef.json",
+				"apidef-*.json",
 				"TykAPIDef-*.json"
 			],
 			"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/v0.1/JSON/draft-07/schema_apidef_lean.json",
@@ -39,7 +41,8 @@ function activate(context) {
 		},
 		{
 			"fileMatch": [
-				"oasapidef.*.json",
+				"oasapidef.json",
+				"oasapidef-*.json",
 				"TykOasApiDef-*.json"
 			],
 			"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/v0.1/JSON/draft-04/schema_TykOasApiDef_3.0.x.json",

--- a/extension.js
+++ b/extension.js
@@ -32,7 +32,7 @@ function activate(context) {
 		{
 			"fileMatch": [
 				"apidef.*.json",
-				"TykDefinition-*.json"
+				"TykAPIDef-*.json",
 			],
 			"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/v0.1/JSON/draft-07/schema_apidef_lean.json",
 			"addedBy": "tyk"

--- a/extension.js
+++ b/extension.js
@@ -32,7 +32,7 @@ function activate(context) {
 		{
 			"fileMatch": [
 				"apidef.*.json",
-				"TykAPIDef-*.json",
+				"TykAPIDef-*.json"
 			],
 			"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/v0.1/JSON/draft-07/schema_apidef_lean.json",
 			"addedBy": "tyk"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 			{
 				"fileMatch": [
 					"apidef.*.json",
-					"TykDefinition-*.json"
+					"TykAPIDef-*.json"
 				],
 				"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/v0.1/JSON/draft-07/schema_apidef_lean.json"
 			},

--- a/package.json
+++ b/package.json
@@ -38,26 +38,29 @@
 		"jsonValidation": [
 			{
 				"fileMatch": [
-					"tyk.*.conf"
+					"tyk.conf",
+					"tyk-*.conf"
 				],
 				"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/v0.1/JSON/draft-07/schema_tyk.oss.conf"
 			},
 			{
 				"fileMatch": [
-					"apikey.*.json"
+					"apikey-*.json"
 				],
 				"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/v0.1/JSON/draft-07/schema_apikey.json"
 			},
 			{
 				"fileMatch": [
-					"apidef.*.json",
+					"apidef.json",
+					"apidef-*.json",
 					"TykAPIDef-*.json"
 				],
 				"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/v0.1/JSON/draft-07/schema_apidef_lean.json"
 			},
 			{
 				"fileMatch": [
-					"oasapidef.*.json",
+					"oasapidef.json",
+					"oasapidef-*.json",
 					"TykOasApiDef-*.json"
 				],
 				"url": "https://raw.githubusercontent.com/TykTechnologies/tyk-schemas/v0.1/JSON/draft-04/schema_TykOasApiDef_3.0.x.json"


### PR DESCRIPTION
This PR updates expected fileName convention `TykDefinition-*.json` to `TykAPIDef-*.json` to match the OAS format. 